### PR TITLE
Change logout endpoint from GET to POST for security

### DIFF
--- a/app/src/front/pages/admin_page/layout.module.scss
+++ b/app/src/front/pages/admin_page/layout.module.scss
@@ -85,7 +85,11 @@
     color: var(--sidebar-danger);
     text-decoration: none;
     font-size: 0.875rem;
-    
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-family: inherit;
+
     &:hover {
         text-decoration: underline;
     }

--- a/app/src/front/pages/admin_page/layout.rs
+++ b/app/src/front/pages/admin_page/layout.rs
@@ -57,13 +57,11 @@ pub fn AdminLayout(children: Children) -> impl IntoView {
                                 view! {
                                     <div class=style::auth_info>
                                         <span class=style::user_email>{user.email.clone()}</span>
-                                        <a
-                                            href="/auth/logout"
-                                            rel="external"
-                                            class=style::logout_link
-                                        >
-                                            "ログアウト"
-                                        </a>
+                                        <form method="post" action="/auth/logout">
+                                            <button type="submit" class=style::logout_link>
+                                                "ログアウト"
+                                            </button>
+                                        </form>
                                     </div>
                                 }
                                     .into_any()

--- a/app/src/server/auth.rs
+++ b/app/src/server/auth.rs
@@ -5,7 +5,7 @@ use axum::{
     extract::Request,
     middleware::Next,
     response::{IntoResponse, Redirect},
-    routing::get,
+    routing::{get, post},
 };
 use oauth2::{
     AuthUrl, AuthorizationCode, ClientId, ClientSecret, CsrfToken, EndpointNotSet, EndpointSet,
@@ -310,5 +310,5 @@ pub fn auth_routes() -> Router<AppState> {
     Router::new()
         .route("/auth/google", get(auth_google))
         .route("/auth/callback", get(auth_callback))
-        .route("/auth/logout", get(auth_logout))
+        .route("/auth/logout", post(auth_logout))
 }

--- a/app/tests/admin_handlers_test.rs
+++ b/app/tests/admin_handlers_test.rs
@@ -1072,7 +1072,7 @@ async fn test_ログアウトするとルートにリダイレクトされるこ
     let cookie = login_and_get_cookie(&app).await;
 
     let request = Request::builder()
-        .method("GET")
+        .method("POST")
         .uri("/auth/logout")
         .header("cookie", &cookie)
         .body(Body::empty())
@@ -1103,7 +1103,7 @@ async fn test_ログアウト後に管理apiにアクセスすると401を返す
 
     // ログアウト
     let request = Request::builder()
-        .method("GET")
+        .method("POST")
         .uri("/auth/logout")
         .header("cookie", &cookie)
         .body(Body::empty())


### PR DESCRIPTION
## Summary
Changed the logout functionality from using a GET request to a POST request for improved security and adherence to REST conventions. Logout operations that modify server state (clearing sessions) should use POST rather than GET.

## Key Changes
- **Backend routing**: Updated `/auth/logout` route from `get(auth_logout)` to `post(auth_logout)` in `app/src/server/auth.rs`
- **Frontend UI**: Replaced the logout anchor link with a form that submits a POST request in `app/src/front/pages/admin_page/layout.rs`
- **Styling**: Updated `.logout_link` styles in `layout.module.scss` to style the button element (removed text-decoration defaults, added button-specific styles like `background: none`, `border: none`, `cursor: pointer`, and `font-family: inherit`)
- **Tests**: Updated logout endpoint tests to use POST method instead of GET in `app/tests/admin_handlers_test.rs`

## Implementation Details
- The logout button now uses a form with `method="post"` and `action="/auth/logout"` instead of a direct link
- Button styling maintains the original visual appearance while properly resetting browser default button styles
- All related tests have been updated to reflect the new POST method requirement

https://claude.ai/code/session_01Sgx6aJqA3DY44pjAyBV25S