### PR TITLE
claude/fix-canonical-tag-Ts01G

### DIFF
--- a/app/src/common/dto.rs
+++ b/app/src/common/dto.rs
@@ -53,6 +53,7 @@ pub struct ArticleDetailDto {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ArticleMetaDto {
     pub(crate) id: RwSignal<String>,
+    pub(crate) slug: RwSignal<String>,
     pub(crate) title: RwSignal<String>,
     pub(crate) description: RwSignal<String>,
     pub(crate) keywords: Vec<RwSignal<String>>,

--- a/app/src/common/dto.rs
+++ b/app/src/common/dto.rs
@@ -35,7 +35,7 @@ pub struct ArticlePageDto {
 /// 記事取得の結果
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ArticleResponse {
-    Found(ArticlePageDto),
+    Found(Box<ArticlePageDto>),
     Redirect(String),
     NotFound(()),
 }

--- a/app/src/common/handlers.rs
+++ b/app/src/common/handlers.rs
@@ -132,7 +132,9 @@ pub(crate) async fn get_article_handler(
     // 1. DB記事をslugで検索
     match published_article_service.fetch_by_slug(&id).await {
         Ok(Some(article)) => {
-            return Ok(ArticleResponse::Found(ArticlePageDto::from(article)));
+            return Ok(ArticleResponse::Found(Box::new(ArticlePageDto::from(
+                article,
+            ))));
         }
         Ok(None) => {
             // DB記事が見つからない場合、リダイレクトマッピングを確認

--- a/app/src/front/pages/article_page/article_page_meta.rs
+++ b/app/src/front/pages/article_page/article_page_meta.rs
@@ -11,7 +11,7 @@ pub(crate) fn ArticlePageMeta(meta: ArticleMetaDto) -> impl IntoView {
         .map(|k| k.get_untracked())
         .collect::<Vec<String>>()
         .join(", ");
-    let canonical_url = format!("{}/articles/{}", ORIGIN, meta.id.get_untracked());
+    let canonical_url = format!("{}/articles/{}", ORIGIN, meta.slug.get_untracked());
     let keywords_json = meta
         .keywords
         .iter()

--- a/app/src/front/pages/preview_article_page/preview_article_page_meta.rs
+++ b/app/src/front/pages/preview_article_page/preview_article_page_meta.rs
@@ -25,7 +25,7 @@ pub(crate) fn PreviewArticlePageMeta(meta: ArticleMetaDto) -> impl IntoView {
         <Meta property="article:published_time" content=meta.published_at.get_untracked() />
         <Meta
             property="og:url"
-            content=format!("{}/articles/{}", ORIGIN, meta.id.get_untracked())
+            content=format!("{}/articles/{}", ORIGIN, meta.slug.get_untracked())
         />
         <Meta name="twitter:card" content="summary_large_image" />
         <Meta name="twitter:title" content=meta.title.get_untracked() />

--- a/app/src/server/models/local_article.rs
+++ b/app/src/server/models/local_article.rs
@@ -80,6 +80,7 @@ impl From<PublishedArticleWithCategories> for ArticlePageDto {
         let first_published_at_rfc3339 = RwSignal::new(published_at_jst.to_rfc3339());
 
         let id = RwSignal::new(article.id.to_string());
+        let slug = RwSignal::new(article.slug.clone());
         let description = RwSignal::new(article.description.unwrap_or_default());
         let og_image_url = RwSignal::new(to_optimize_og_image_url(
             article
@@ -99,6 +100,7 @@ impl From<PublishedArticleWithCategories> for ArticlePageDto {
             },
             article_meta_dto: ArticleMetaDto {
                 id,
+                slug,
                 title,
                 description,
                 keywords: category,

--- a/app/src/server/models/local_article.rs
+++ b/app/src/server/models/local_article.rs
@@ -80,7 +80,7 @@ impl From<PublishedArticleWithCategories> for ArticlePageDto {
         let first_published_at_rfc3339 = RwSignal::new(published_at_jst.to_rfc3339());
 
         let id = RwSignal::new(article.id.to_string());
-        let slug = RwSignal::new(article.slug.clone());
+        let slug = RwSignal::new(article.slug);
         let description = RwSignal::new(article.description.unwrap_or_default());
         let og_image_url = RwSignal::new(to_optimize_og_image_url(
             article

--- a/app/src/server/models/newt_article.rs
+++ b/app/src/server/models/newt_article.rs
@@ -121,6 +121,7 @@ impl From<NewtArticle> for ArticlePageDto {
         );
         let first_published_at_rfc3339 = RwSignal::new(first_published_at_date_time.to_rfc3339());
         let id = RwSignal::new(value.id);
+        let slug = RwSignal::new(value.slug);
         let description = RwSignal::new(
             value
                 .meta
@@ -148,6 +149,7 @@ impl From<NewtArticle> for ArticlePageDto {
             },
             article_meta_dto: ArticleMetaDto {
                 id,
+                slug,
                 title,
                 description,
                 keywords: category,


### PR DESCRIPTION
ArticleMetaDtoにslugフィールドを追加し、canonical URLとog:urlの
生成でmeta.idではなくmeta.slugを参照するように変更。
これにより /articles/{UUID} ではなく /articles/{slug} が正しく出力される。

https://claude.ai/code/session_01F7pLRdzmRSSC5bhy84nCaF