### PR TITLE
記事詳細の<time datetime>属性をISO形式で出力するよう修正

### DIFF
--- a/app/src/common/dto.rs
+++ b/app/src/common/dto.rs
@@ -48,6 +48,7 @@ pub struct ArticleDetailDto {
     pub(crate) body: RwSignal<String>,
     pub(crate) category: Vec<RwSignal<String>>,
     pub(crate) first_published_at: RwSignal<String>,
+    pub(crate) first_published_at_iso: RwSignal<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/app/src/constants.rs
+++ b/app/src/constants.rs
@@ -16,6 +16,7 @@ pub(crate) const HOUR: i32 = 3600;
 /// JST (UCT+09:00)
 pub(crate) const JST_TZ: i32 = 9;
 pub(crate) const DATE_DISPLAY_FORMAT: &str = "%Y年%m月%d日";
+pub(crate) const DATE_ISO_FORMAT: &str = "%Y-%m-%d";
 pub(crate) const ROMIRA_GITHUB_URL: &str = "https://github.com/Romira915";
 pub(crate) const ROMIRA_X_URL: &str = "https://x.com/Romira915";
 pub(crate) const QIITA_BASE_URL: &str = "https://qiita.com";

--- a/app/src/front/components/article_detail.rs
+++ b/app/src/front/components/article_detail.rs
@@ -27,13 +27,8 @@ pub(crate) fn ArticleDetail(article: ArticleDetailDto) -> impl IntoView {
                         .collect_view()}
                 </ul>
                 <p class=article_detail_style::article_meta_published_at>
-                    // FIXME: まじめにやる
                     <time datetime=article
-                        .first_published_at
-                        .read()
-                        .replace("年", "-")
-                        .replace("月", "-")
-                        .replace("日", "")>{article.first_published_at}</time>
+                        .first_published_at_iso>{article.first_published_at}</time>
                 </p>
             </div>
             <figure class=article_detail_style::article_cover>

--- a/app/src/server/models/local_article.rs
+++ b/app/src/server/models/local_article.rs
@@ -6,7 +6,7 @@ use crate::common::dto::{
 use crate::common::imgix_url::{extract_base_url, generate_srcset, is_imgix_url};
 use crate::common::markdown::convert_markdown_to_html;
 use crate::constants::{
-    COVER_IMAGE_WIDTHS, DATE_DISPLAY_FORMAT, HOUR, JST_TZ, THUMBNAIL_NO_IMAGE_URL,
+    COVER_IMAGE_WIDTHS, DATE_DISPLAY_FORMAT, DATE_ISO_FORMAT, HOUR, JST_TZ, THUMBNAIL_NO_IMAGE_URL,
 };
 use crate::server::utils::url::{
     to_optimize_cover_image_url, to_optimize_og_image_url, to_optimize_thumbnail_url,
@@ -77,6 +77,8 @@ impl From<PublishedArticleWithCategories> for ArticlePageDto {
         let updated_at_rfc3339 = RwSignal::new(updated_at_jst.to_rfc3339());
         let first_published_at =
             RwSignal::new(published_at_jst.format(DATE_DISPLAY_FORMAT).to_string());
+        let first_published_at_iso =
+            RwSignal::new(published_at_jst.format(DATE_ISO_FORMAT).to_string());
         let first_published_at_rfc3339 = RwSignal::new(published_at_jst.to_rfc3339());
 
         let id = RwSignal::new(article.id.to_string());
@@ -97,6 +99,7 @@ impl From<PublishedArticleWithCategories> for ArticlePageDto {
                 body,
                 category: category.clone(),
                 first_published_at,
+                first_published_at_iso,
             },
             article_meta_dto: ArticleMetaDto {
                 id,

--- a/app/src/server/models/newt_article.rs
+++ b/app/src/server/models/newt_article.rs
@@ -3,7 +3,7 @@ use crate::common::dto::{
 };
 use crate::common::imgix_url::{extract_base_url, generate_srcset, is_imgix_url};
 use crate::constants::{
-    COVER_IMAGE_WIDTHS, DATE_DISPLAY_FORMAT, HOUR, JST_TZ, THUMBNAIL_NO_IMAGE_URL,
+    COVER_IMAGE_WIDTHS, DATE_DISPLAY_FORMAT, DATE_ISO_FORMAT, HOUR, JST_TZ, THUMBNAIL_NO_IMAGE_URL,
 };
 use crate::server::utils::url::{
     to_optimize_cover_image_url, to_optimize_og_image_url, to_optimize_thumbnail_url,
@@ -119,6 +119,11 @@ impl From<NewtArticle> for ArticlePageDto {
                 .format(DATE_DISPLAY_FORMAT)
                 .to_string(),
         );
+        let first_published_at_iso = RwSignal::new(
+            first_published_at_date_time
+                .format(DATE_ISO_FORMAT)
+                .to_string(),
+        );
         let first_published_at_rfc3339 = RwSignal::new(first_published_at_date_time.to_rfc3339());
         let id = RwSignal::new(value.id);
         let slug = RwSignal::new(value.slug);
@@ -146,6 +151,7 @@ impl From<NewtArticle> for ArticlePageDto {
                 body,
                 category: category.clone(),
                 first_published_at,
+                first_published_at_iso,
             },
             article_meta_dto: ArticleMetaDto {
                 id,


### PR DESCRIPTION
これまで日本語表示用 "YYYY年MM月DD日" 文字列を replace で機械的に
"YYYY-MM-DD" に組み立てて datetime 属性に渡していた (FIXME 残置)。
DTO に first_published_at_iso を追加し、変換元 (local/newt) で
正しく ISO 8601 形式を生成して受け渡すよう修正。

https://claude.ai/code/session_01LYVnq8rzeiGR7JvE8KzikU