### PR TITLE
chore: 不要な dead_code 許容属性の削除 (Phase 2)

### DIFF
--- a/app/src/front/components/article_detail.rs
+++ b/app/src/front/components/article_detail.rs
@@ -1,11 +1,17 @@
-#![allow(dead_code)]
-
 use crate::common::dto::ArticleDetailDto;
 use leptos::prelude::*;
 use stylance::import_style;
 
-import_style!(pub(crate) article_detail_style, "article_detail.module.scss");
-import_style!(pub(crate) article_body_style, "article_body.module.scss");
+import_style!(
+    #[allow(dead_code)]
+    pub(crate) article_detail_style,
+    "article_detail.module.scss"
+);
+import_style!(
+    #[allow(dead_code)]
+    pub(crate) article_body_style,
+    "article_body.module.scss"
+);
 
 #[component]
 pub(crate) fn ArticleDetail(article: ArticleDetailDto) -> impl IntoView {

--- a/app/src/front/pages/admin_page/article_editor/view.rs
+++ b/app/src/front/pages/admin_page/article_editor/view.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 mod article_editor_page;
 mod article_form;
 mod editor_header;
@@ -15,4 +13,8 @@ use markdown_preview::MarkdownPreview;
 
 use stylance::import_style;
 
-import_style!(pub(super) style, "article_editor.module.scss");
+import_style!(
+    #[allow(dead_code)]
+    pub(super) style,
+    "article_editor.module.scss"
+);

--- a/app/src/front/pages/admin_page/article_editor/view/article_editor_page.rs
+++ b/app/src/front/pages/admin_page/article_editor/view/article_editor_page.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use leptos::prelude::*;
 use leptos_router::hooks::use_params_map;
 

--- a/app/src/server/auth.rs
+++ b/app/src/server/auth.rs
@@ -200,13 +200,6 @@ pub async fn get_current_user(session: &Session) -> Option<AuthUser> {
     session.get(SESSION_USER_KEY).await.unwrap_or(None)
 }
 
-/// Check if user is authenticated (internal)
-#[allow(dead_code)]
-#[instrument(skip_all)]
-pub async fn is_authenticated(session: &Session) -> bool {
-    get_current_user(session).await.is_some()
-}
-
 /// Check if the given email is in the ADMIN_EMAILS allowlist.
 #[instrument]
 fn is_admin_email(email: &str) -> bool {

--- a/app/src/server/services/signing.rs
+++ b/app/src/server/services/signing.rs
@@ -16,7 +16,6 @@ pub enum SigningError {
 }
 
 /// 署名付きURL生成サービスのトレイト
-#[allow(dead_code)]
 pub trait SigningService {
     async fn generate_upload_url(
         &self,
@@ -30,8 +29,6 @@ pub trait SigningService {
         object_path: &str,
         duration_secs: u64,
     ) -> Result<String, SigningError>;
-
-    fn bucket(&self) -> &str;
 }
 
 /// GCS署名付きURL生成サービス
@@ -140,10 +137,5 @@ impl SigningService for GcsSigningService {
         .await
         .map_err(|e| SigningError::SigningError(format!("Task join error: {}", e)))?
         .map_err(|e| SigningError::SigningError(e.to_string()))
-    }
-
-    /// バケット名を取得
-    fn bucket(&self) -> &str {
-        self.bucket.as_str()
     }
 }


### PR DESCRIPTION
## Summary
- 以下のコンポーネントおよびサーバーサイドコードで、不要な `allow(dead_code)` 属性を削除しました。
  - `article_detail.rs`
  - `article_editor/view.rs`
  - `article_editor_page.rs`
  - `auth.rs` (未使用関数の削除も含む)
  - `services/signing.rs` (未使用メソッドの削除も含む)
- 一部の `import_style!` マクロ由来の未使用定数警告は、別タスクで対応予定のため今回はそのままにしています。

## Test Plan
- CIでのビルドとLint（`cargo clippy`）が成功することを確認（既知の `import_style!` 由来の警告は許容）
- ローカルでのテスト実行（一部環境変数不足によるテスト失敗は今回の変更とは無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)