### PR TITLE
refactor: プレビュー画面のデータ取得元をローカルDBに変更

### DIFF
--- a/app/src/common/handlers.rs
+++ b/app/src/common/handlers.rs
@@ -172,35 +172,38 @@ pub(crate) async fn get_preview_article_handler(
     id: String,
 ) -> Result<Option<ArticlePageDto>, ServerFnError<GetArticleError>> {
     use crate::AppState;
+    use crate::common::dto::ArticlePageDto;
     use crate::server::http::response::set_preview_article_page_cache_control;
     use leptos_axum::ResponseOptions;
+    use uuid::Uuid;
 
     let app_state = expect_context::<AppState>();
-    let newt_article_service = app_state.newt_article_service;
+    let draft_article_service = app_state.draft_article_service;
     let response = expect_context::<ResponseOptions>();
 
     set_preview_article_page_cache_control(&response);
 
-    let article = newt_article_service.fetch_preview_article(&id).await;
-    let article = match article {
-        Ok(article) => article,
+    let uuid = match Uuid::parse_str(&id) {
+        Ok(uuid) => uuid,
+        Err(_) => return Ok(None),
+    };
+
+    let article = draft_article_service.fetch_by_id(uuid).await;
+    match article {
+        Ok(Some(article)) => Ok(Some(ArticlePageDto::from(article))),
+        Ok(None) => {
+            response.set_status(StatusCode::NOT_FOUND);
+            Ok(None)
+        }
         Err(err) => {
             response.set_status(StatusCode::INTERNAL_SERVER_ERROR);
             tracing::error!(
                 error = err.to_string(),
-                "Failed to get article from NewtArticleService",
+                "Failed to get article from DraftArticleService",
             );
-            return Err(ServerFnError::from(
-                GetArticleError::NewtArticleServiceGetArticle(
-                    "Failed to get article from NewtArticleService".to_string(),
-                ),
-            ));
+            Err(ServerFnError::from(GetArticleError::DatabaseError(
+                err.to_string(),
+            )))
         }
-    };
-
-    if article.is_none() {
-        response.set_status(StatusCode::NOT_FOUND);
     }
-
-    Ok(article.map(ArticlePageDto::from))
 }

--- a/app/src/server/models/local_article.rs
+++ b/app/src/server/models/local_article.rs
@@ -11,7 +11,7 @@ use crate::constants::{
 use crate::server::utils::url::{
     to_optimize_cover_image_url, to_optimize_og_image_url, to_optimize_thumbnail_url,
 };
-use blog_romira_dev_cms::PublishedArticleWithCategories;
+use blog_romira_dev_cms::{DraftArticleWithCategories, PublishedArticleWithCategories};
 use chrono::{FixedOffset, NaiveDateTime, TimeZone, Utc};
 use leptos::prelude::RwSignal;
 use tracing::instrument;
@@ -82,6 +82,73 @@ impl From<PublishedArticleWithCategories> for ArticlePageDto {
         let first_published_at_iso =
             RwSignal::new(published_at_jst.format(DATE_ISO_FORMAT).to_string());
         let first_published_at_rfc3339 = RwSignal::new(published_at_jst.to_rfc3339());
+
+        let id = RwSignal::new(article.id.to_string());
+        let slug = RwSignal::new(article.slug);
+        let description = RwSignal::new(article.description.unwrap_or_default());
+        let og_image_url = RwSignal::new(to_optimize_og_image_url(
+            article
+                .cover_image_url
+                .as_deref()
+                .unwrap_or(THUMBNAIL_NO_IMAGE_URL),
+        ));
+
+        Self {
+            article_detail_dto: ArticleDetailDto {
+                title,
+                cover_image_url,
+                cover_image_srcset,
+                body,
+                category: category.clone(),
+                first_published_at,
+                first_published_at_iso,
+            },
+            article_meta_dto: ArticleMetaDto {
+                id,
+                slug,
+                title,
+                description,
+                keywords: category,
+                og_image_url,
+                published_at: updated_at_rfc3339,
+                first_published_at: first_published_at_rfc3339,
+            },
+        }
+    }
+}
+
+impl From<DraftArticleWithCategories> for ArticlePageDto {
+    #[instrument(skip(value))]
+    fn from(value: DraftArticleWithCategories) -> Self {
+        let article = value.article;
+        let title = RwSignal::new(article.title);
+        let cover_image_raw = article
+            .cover_image_url
+            .as_deref()
+            .unwrap_or(THUMBNAIL_NO_IMAGE_URL);
+        let cover_image_url = RwSignal::new(to_optimize_cover_image_url(cover_image_raw));
+        let cover_image_srcset = RwSignal::new(if is_imgix_url(cover_image_raw) {
+            generate_srcset(extract_base_url(cover_image_raw), &COVER_IMAGE_WIDTHS)
+        } else {
+            String::new()
+        });
+        let body = RwSignal::new(sanitize_html(&convert_markdown_to_html(
+            article.body.as_str(),
+        )));
+        let category: Vec<RwSignal<String>> = value
+            .categories
+            .iter()
+            .map(|category| RwSignal::new(category.name.clone()))
+            .collect();
+
+        // プレビュー用なので現在時刻を仮の日付とする（あるいは保存された日時）
+        let updated_at_jst = to_jst(article.updated_at);
+        let updated_at_rfc3339 = RwSignal::new(updated_at_jst.to_rfc3339());
+        let first_published_at =
+            RwSignal::new(updated_at_jst.format(DATE_DISPLAY_FORMAT).to_string());
+        let first_published_at_iso =
+            RwSignal::new(updated_at_jst.format(DATE_ISO_FORMAT).to_string());
+        let first_published_at_rfc3339 = RwSignal::new(updated_at_jst.to_rfc3339());
 
         let id = RwSignal::new(article.id.to_string());
         let slug = RwSignal::new(article.slug);

--- a/app/src/server/services/newt.rs
+++ b/app/src/server/services/newt.rs
@@ -1,6 +1,5 @@
 use crate::SERVER_CONFIG;
 use crate::error::NewtArticleServiceError;
-use crate::server::models::newt_article::NewtArticle;
 use crate::server::models::newt_author::Author;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -10,7 +9,6 @@ use tracing::instrument;
 pub(crate) struct NewtArticleService {
     client: reqwest::Client,
     newt_cdn_base_url: Arc<String>,
-    newt_base_url: Arc<String>,
 }
 
 impl NewtArticleService {
@@ -18,61 +16,12 @@ impl NewtArticleService {
     pub(crate) fn new(
         client: reqwest::Client,
         newt_cdn_base_url: impl ToString + Debug,
-        newt_base_url: impl ToString + Debug,
+        _newt_base_url: impl ToString + Debug, // TODO: Remove this param in the future
     ) -> Self {
         Self {
             client,
             newt_cdn_base_url: Arc::new(newt_cdn_base_url.to_string()),
-            newt_base_url: Arc::new(newt_base_url.to_string()),
         }
-    }
-
-    #[instrument]
-    async fn fetch_article<T>(
-        &self,
-        article_id: T,
-        is_preview: bool,
-    ) -> Result<Option<NewtArticle>, NewtArticleServiceError>
-    where
-        T: std::fmt::Display + Debug,
-    {
-        let (base_url, api_token) = if is_preview {
-            (&self.newt_base_url, &SERVER_CONFIG.newt_api_token)
-        } else {
-            (&self.newt_cdn_base_url, &SERVER_CONFIG.newt_cdn_api_token)
-        };
-
-        let response = self
-            .client
-            .get(format!("{base_url}/blog/article/{article_id}"))
-            .bearer_auth(api_token)
-            .send()
-            .await?;
-
-        if response.status() == reqwest::StatusCode::NOT_FOUND {
-            return Ok(None);
-        }
-
-        if !response.status().is_success() {
-            return Err(NewtArticleServiceError::UnexpectedStatusCode(
-                response.status(),
-            ));
-        }
-
-        let article: NewtArticle = response.json().await?;
-
-        Ok(Some(article))
-    }
-
-    #[instrument]
-    pub(crate) async fn fetch_preview_article<T>(
-        &self,
-        article_id: T,
-    ) -> Result<Option<NewtArticle>, NewtArticleServiceError>
-    where
-        T: std::fmt::Display + Debug,
-    {
-        self.fetch_article(article_id, true).await
     }
 
     #[instrument]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U blog -d blog_romira_dev"]
       interval: 5s


### PR DESCRIPTION
## Summary
- `get_preview_article_handler` で `draft_article_service` を使用してローカルDBから下書き記事を取得するように変更
- `ArticlePageDto` へ `DraftArticleWithCategories` からの変換実装を追加
- 使われなくなった `NewtArticleService` のプレビュー関連のメソッド（`fetch_article`, `fetch_preview_article`）とフィールドを削除
- `docker-compose.yml` で不要なデータマウントを削除し、Postgres 18 向けの推奨構成に変更

## Test plan
- [x] `just test` がすべて成功することを確認
- [x] `cargo clippy` で警告が出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)