### PR TITLE
fix: wasm-bindgen-cli のバージョンを Cargo.lock と同期 (0.2.106 → 0.2.122)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install build tools
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-leptos@0.3.2,stylance-cli@0.7.4,wasm-bindgen-cli@0.2.106,sqlx-cli@0.8.6
+          tool: cargo-leptos@0.3.2,stylance-cli@0.7.4,wasm-bindgen-cli@0.2.122,sqlx-cli@0.8.6
 
       - name: Build
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ tracing = "0.1.44"
 tracing-wasm = "0.2.1"
 url = "2.5.7"
 uuid = { version = "1", features = ["v7", "serde", "js"] }
-wasm-bindgen = "0.2.106"
+wasm-bindgen = "0.2.122"
 gloo-net = { version = "0.6", default-features = false, features = ["http"] }
 comrak = { version = "0.49", default-features = false }
 ammonia = "4.1"

--- a/justfile
+++ b/justfile
@@ -1,8 +1,8 @@
 setup:
     #!/bin/bash -eux
     rustup target add wasm32-unknown-unknown
-    if ! cargo install --list | grep -q 'wasm-bindgen-cli v0.2.106'; then
-        cargo install --force wasm-bindgen-cli --version=0.2.106 --locked
+    if ! cargo install --list | grep -q 'wasm-bindgen-cli v0.2.122'; then
+        cargo install --force wasm-bindgen-cli --version=0.2.122 --locked
     fi
     if ! cargo install --list | grep -q 'cargo-leptos v0.3.2'; then
         cargo install --force cargo-leptos --version=0.3.2 --locked


### PR DESCRIPTION
## Summary
- `Cargo.lock` で解決された `wasm-bindgen` 0.2.122 に対し、`wasm-bindgen-cli` が 0.2.106 のままだったため、WASM リンク時に duplicate symbol エラー（`UnderlyingByteSource`/`UnderlyingSink`/`UnderlyingSource`）が発生していた
- CI (`deploy.yml`)、`justfile`、`Cargo.toml` の wasm-bindgen バージョンを 0.2.106 → 0.2.122 に統一

## Test Plan
- [ ] CI (deploy) の Build ジョブが成功すること
- [ ] `just setup` で `wasm-bindgen-cli` が正しくインストールされること