### PR TITLE
WASMビルドをCIで検証

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,3 +120,26 @@ jobs:
 
       - name: Test
         run: just test-nextest
+
+  wasm-build:
+    runs-on: ubuntu-24.04
+    env:
+      SQLX_OFFLINE: true
+      ASSETS_ROOT: https://cdn.blog.romira.dev
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Free disk space
+        uses: ./.github/actions/free-disk-space
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "ci"
+          cache-targets: true
+
+      - name: Install wasm target
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Build front wasm
+        run: cargo build -p blog-romira-dev-front --target wasm32-unknown-unknown --profile wasm-release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,7 +334,7 @@ dependencies = [
  "leptos_router",
  "mockito",
  "oauth2",
- "reqwest 0.12.28",
+ "reqwest 0.13.4",
  "select",
  "serde",
  "serde_json",
@@ -3742,14 +3742,12 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots",
 ]
@@ -3792,7 +3790,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.5.0",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -4227,7 +4225,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.5.0",
+ "wasm-streams",
  "web-sys",
  "xxhash-rust",
 ]
@@ -5698,19 +5696,6 @@ dependencies = [
  "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
-]
-
-[[package]]
-name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ leptos_axum = { version = "0.8.7", default-features = false }
 leptos_meta = { version = "0.8.5", default-features = false }
 leptos_router = { version = "0.8.11", default-features = false }
 mockito = "1.7.1"
-reqwest = { version = "0.12.28", default-features = false, features = ["json", "rustls-tls", "stream"] }
+reqwest = { version = "0.13.4", default-features = false, features = ["json", "rustls", "stream"] }
 select = "0.6.1"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.147"


### PR DESCRIPTION
## Summary
- reqwest を 0.13.4 に更新し、front WASM 側の wasm-streams を 0.5.0 に統一
- PR CI に front WASM build job を追加
- deploy 前に rust-lld の duplicate symbol などの WASM link エラーを検出できるように変更

## Test Plan
- ASSETS_ROOT=https://cdn.blog.romira.dev cargo build -p blog-romira-dev-front --target wasm32-unknown-unknown --profile wasm-release
- SQLX_OFFLINE=true just clippy
- SQLX_OFFLINE=true just test（ローカルでは Docker がなく DB 接続不可のため admin_handlers_test が PoolTimedOut で失敗）